### PR TITLE
Fixing log level for retry message

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -1180,7 +1180,7 @@ public class AmazonHttpClient {
             if (log.isTraceEnabled()) {
                 log.trace(sdkClientException.getMessage() + (willRetry ? " Request will be retried." : ""), e);
             } else if (log.isDebugEnabled()) {
-                log.trace(sdkClientException.getMessage() + (willRetry ? " Request will be retried." : ""));
+                log.debug(sdkClientException.getMessage() + (willRetry ? " Request will be retried." : ""));
             }
             if (!willRetry) {
                 throw lastReset(sdkClientException);


### PR DESCRIPTION
Moving the log level to debug for messages in handleRetryableException without a stacktrace